### PR TITLE
Updated local setup documentation for Docker and Supabase

### DIFF
--- a/docs/developers/local-setup.md
+++ b/docs/developers/local-setup.md
@@ -14,7 +14,7 @@ Before starting, ensure you have the following installed:
 | Requirement | Version | Notes |
 |-------------|---------|-------|
 | Node.js | v22 (recommended) | Use [nvm](https://github.com/nvm-sh/nvm) for version management |
-| Docker | Latest | Required for local Supabase Can use [Docker desktop](https://www.docker.com/products/docker-desktop/) to quickly setup a docker daemon for development. |
+| Docker | Latest | Required for local Supabase. Can use [Docker desktop](https://www.docker.com/products/docker-desktop/) to quickly setup a docker daemon for development. |
 | Git | Latest | For cloning the repository |
 
 ## Quick Start (Staging Backend)
@@ -113,7 +113,7 @@ For development requiring database changes, RLS policy modifications, or running
 
    :::note
    In newer versions of supabase, after `supabase start`, you may see the following instead
-   ```
+   ```bash
    API URL: http://127.0.0.1:54321
    Publishable key: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...
    Secret key: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...

--- a/docs/developers/local-setup.md
+++ b/docs/developers/local-setup.md
@@ -92,18 +92,47 @@ For development requiring database changes, RLS policy modifications, or running
 4. **Configure environment variables**
 
    After `supabase start`, you'll see output like:
-   ```
-   API URL: http://127.0.0.1:54321
-   anon key: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...
-   service_role key: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...
-   ```
+
+```bash
+supabase local development setup is running.
+
+╭──────────────────────────────────────╮
+│ 🔧 Development Tools                 │
+├─────────┬────────────────────────────┤
+│ Studio  │ http://127.0.0.1:54323     │
+│ Mailpit │ http://127.0.0.1:54324     │
+│ MCP     │ http://127.0.0.1:54321/mcp │
+╰─────────┴────────────────────────────╯
+
+╭─────────────────────────────────────────────────╮
+│ 🌐 APIs                                         │
+├─────────────┬───────────────────────────────────┤
+│ Project URL │ http://127.0.0.1:54321            │
+│ REST        │ http://127.0.0.1:54321/rest/v1    │
+│ GraphQL     │ http://127.0.0.1:54321/graphql/v1 │
+╰─────────────┴───────────────────────────────────╯
+
+╭───────────────────────────────────────────────────────────────╮
+│ ⛁ Database                                                    │
+├─────┬─────────────────────────────────────────────────────────┤
+│ URL │ postgresql://postgres:postgres@127.0.0.1:54322/postgres │
+╰─────┴─────────────────────────────────────────────────────────╯
+
+╭──────────────────────────────────────────────────────────────╮
+│ 🔑 Authentication Keys                                       │
+├─────────────┬────────────────────────────────────────────────┤
+│ Publishable │ sb_publishable_...                             │
+│ Secret      │ sb_secret_...                                  │
+╰─────────────┴────────────────────────────────────────────────╯
+
+```
 
    Update your `.env.local`:
    ```bash
    SUPABASE_URL=http://127.0.0.1:54321
    NEXT_PUBLIC_SUPABASE_URL=http://127.0.0.1:54321
-   NEXT_PUBLIC_SUPABASE_ANON_KEY=<anon key from output>
-   SUPABASE_SERVICE_ROLE_KEY=<service_role key from output>
+   NEXT_PUBLIC_SUPABASE_ANON_KEY=<publishable key from output>
+   SUPABASE_SERVICE_ROLE_KEY=<secret key from output>
    ENABLE_SIGNUPS=true
    ```
 
@@ -111,16 +140,6 @@ For development requiring database changes, RLS policy modifications, or running
    Never expose `SUPABASE_SERVICE_ROLE_KEY` to the browser or commit it to version control. Keep it in server-only code and CI secrets.
    :::
 
-   :::note
-   In newer versions of supabase, after `supabase start`, you may see the following instead
-   ```bash
-   API URL: http://127.0.0.1:54321
-   Publishable key: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...
-   Secret key: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...
-   ```
-   The `publishable key` is the same as the `anon key`. The `secret key` is the same as the `service_role` key.
-   See [this Supabase blog post](https://supabase.com/blog/jwt-signing-keys#api-keys-to-fix-anon-and-service_role) for details on this change and its timeline.
-   :::
 
 5. **Build the application**
    ```bash

--- a/docs/developers/local-setup.md
+++ b/docs/developers/local-setup.md
@@ -14,7 +14,7 @@ Before starting, ensure you have the following installed:
 | Requirement | Version | Notes |
 |-------------|---------|-------|
 | Node.js | v22 (recommended) | Use [nvm](https://github.com/nvm-sh/nvm) for version management |
-| Docker | Latest | Required for local Supabase |
+| Docker | Latest | Required for local Supabase Can use [Docker desktop](https://www.docker.com/products/docker-desktop/) to quickly setup a docker daemon for development. |
 | Git | Latest | For cloning the repository |
 
 ## Quick Start (Staging Backend)
@@ -109,6 +109,17 @@ For development requiring database changes, RLS policy modifications, or running
 
    :::warning
    Never expose `SUPABASE_SERVICE_ROLE_KEY` to the browser or commit it to version control. Keep it in server-only code and CI secrets.
+   :::
+
+   :::note
+   In newer versions of supabase, after `supabase start`, you may see the following instead
+   ```
+   API URL: http://127.0.0.1:54321
+   Publishable key: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...
+   Secret key: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...
+   ```
+   The `publishable key` is the same as the `anon key`. The `secret key` is the same as the `service_role` key.
+   See [this Supabase blog post](https://supabase.com/blog/jwt-signing-keys#api-keys-to-fix-anon-and-service_role) for details on this change and its timeline.
    :::
 
 5. **Build the application**


### PR DESCRIPTION
Updated Docker requirement note and added information about how the new Supabase API keys relate to the ones used in the current local setup.

- Added a link to Docker Desktop for new users to get a quick Docker daemon running. Can be replaced with a CLI tutorial instead.
- Added information about the new publishable and secret keys. Newer versions of Supabase are switching to this soon and npm currently installs the latest stable version which reports the keys differently.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified local development setup, recommending Docker Desktop as an easy way to run a Docker daemon.
  * Replaced brief key snippet with a detailed local status block showing endpoints and keys for local Supabase services.
  * Updated .env examples to label NEXT_PUBLIC_SUPABASE_ANON_KEY as the publishable key and SUPABASE_SERVICE_ROLE_KEY as the secret key.
  * Added build/start/seed steps and commands and adjusted surrounding guidance and formatting.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->